### PR TITLE
Update build for version 1.5 of Android Gradle plugin.

### DIFF
--- a/app-mvvm/build.gradle
+++ b/app-mvvm/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.application'
-apply plugin: 'com.android.databinding'
 
 android {
     compileSdkVersion rootProject.ext.androidCompileSdkVersion
@@ -12,6 +11,11 @@ android {
         versionCode 1
         versionName "1.0"
     }
+
+    dataBinding {
+        enabled = true
+    }
+
     buildTypes {
         release {
             minifyEnabled false

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
-        classpath "com.android.databinding:dataBinder:1.0-rc3"
+        classpath 'com.android.tools.build:gradle:1.5.0'
     }
 }
 


### PR DESCRIPTION
The MVVM example would not build for me in most recent Android studio. I am not sure whether I did something wrong, but it looks like version 1.5 of the gradle plugin has more natural support for databinding, and this patch makes use of that.
